### PR TITLE
prepare for the single seat admin special election

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -102,4 +102,4 @@ self_assignable_roles_descriptions =\
 role_requests = "role-requests"
 polls_category = "Administration"
 voting_age_days = 14
-seat_count = 5
+seat_count = 1

--- a/src/voting/polls.py
+++ b/src/voting/polls.py
@@ -168,7 +168,7 @@ class Polls(commands.Cog):
 
         server_join_date = ctx.author.joined_at.replace(tzinfo=timezone.utc)
         bad_hardcoded_date = datetime.fromisoformat(
-            "2023-12-11 03:59:59.000000+00:00")
+            "2024-03-15 03:59:59.000000+00:00")
 
         server_join_ok = server_join_date < bad_hardcoded_date
 


### PR DESCRIPTION
Only one open seat and more recent join requirement date. Most elections going forward will be special elections to fill vacant seats per the new policy so this is probably the way to leave it for a while i guess.