### PR TITLE
[FEATURE] Thread based race rooms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Adding token.txt
+token.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gorialis/discord.py:3.9-alpine-pypi-minimal
+FROM gorialis/discord.py:3.12.2-alpine-pypi-minimal
 RUN python -m pip install redis
 RUN python -m pip install -U discord.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 attrs==20.1.0
 idna==2.10
 multidict==4.7.6
-yarl==1.5.1
-aiohttp==3.8.5
+yarl==1.9.7
+aiohttp==3.10.5
 chardet==3.0.4
 pymongo==3.11.0
 discord.py==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ yarl==1.5.1
 aiohttp==3.8.5
 chardet==3.0.4
 pymongo==3.11.0
-discord.py==2.0.1
-redis~=3.5.3
+discord.py==2.4.0
+redis~=5.0.8

--- a/src/races.py
+++ b/src/races.py
@@ -142,7 +142,7 @@ class Races(commands.Cog):
         active_races[racethread.id] = race
         race.channel = racethread
 
-        race.message = await ctx.channel.send(
+        race.message = await racethread.send(
             "join this multiworld with the ?join command, @ any"
             + " people that will be on your team if playing coop. "
         )

--- a/src/races.py
+++ b/src/races.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 import random
 
 from urllib.parse import parse_qs, urlparse
@@ -30,8 +29,10 @@ def allow_seed_rolling(ctx):
 def is_call_for_races(ctx):
     return ctx.channel.name in constants.call_for_races_channels
 
+
 def is_call_for_multiworld(ctx):
     return ctx.channel.name in constants.call_for_races_channels
+
 
 def is_race_room(ctx):
     return ctx.channel.id in active_races.keys()
@@ -103,39 +104,25 @@ class Races(commands.Cog):
         if name is None:
             await ctx.author.send("you forgot to name your race")
             return
-        # overwrites = {
-        #     ctx.guild.default_role: discord.PermissionOverwrite(
-        #         read_messages=False), ctx.guild.me: discord
-        #     .PermissionOverwrite(
-        #         read_messages=True)}
-        racechannel = await ctx.guild\
-            .create_text_channel(name,
-                                 category=get(ctx.guild.categories,
-                                              name=constants.races_category),
-                                 reason="bot generated channel for a race,"
-                                        + " will be deleted after race "
-                                          "finishes")
-        race = Race(racechannel.id, name)
-        active_races[racechannel.id] = race
-        race.role = await ctx.guild.create_role(name=race.id,
-                                                reason="role for a race")
-        race.channel = racechannel
-        await racechannel.set_permissions(race.role, read_messages=True,
-                                          send_messages=True)
-        race.message = await ctx.channel.send(
-            "join this race with the following ?join command, @ any"
-            + " people that will be on your team if playing coop. "
-            + "Spectate the race with the following ?spectate command\n"
-            + "?join " + str(racechannel.id) + "\n"
-            + "?spectate " + str(racechannel.id))
-        aliases[racechannel.id] = dict()  # for team races
-        teamslist[racechannel.id] = dict()
+        message_str = "A new race has been started!\nJoin this race with the" \
+            + " ?join command, @ any people that will be on your team if playing coop."
+
+        racethread = await ctx.channel.create_thread(
+            name=name,
+            message=ctx.message,
+            reason="bot generated thread for a race"
+        )
+        race = Race(racethread.id, name)
+        active_races[racethread.id] = race
+        race.channel = racethread
+        race.message = await racethread.send(message_str)
+        aliases[racethread.id] = dict()  # for team races
+        teamslist[racethread.id] = dict()
         race.owner = ctx.author.id
         # just trying to hack around the permission bug we've been dealing
         # with throughout 2023. cause unknown but maybe this helps?
+        await race.message.pin()
         await asyncio.sleep(5)
-        await racechannel.set_permissions(race.role, read_messages=True,
-                                          send_messages=True)
 
     @commands.command(aliases=['ap', 'multiworld', 'archipelago'])
     @commands.check(is_call_for_multiworld)
@@ -145,28 +132,22 @@ class Races(commands.Cog):
             await ctx.author.send("you forgot to name your multiworld")
             return
 
-        racechannel = await ctx.guild \
-            .create_text_channel(name,
-                                 category=get(ctx.guild.categories,
-                                              name=constants.multiworld_category),
-                                 reason="bot generated channel for a multiworld,"
-                                        + " will be deleted after multiworld "
-                                          "finishes")
-        race = Race(racechannel.id, name, lockable=True)
-        active_races[racechannel.id] = race
-        race.role = await ctx.guild.create_role(name=race.id,
-                                                reason="role for a multiworld")
-        race.channel = racechannel
-        await racechannel.set_permissions(race.role, read_messages=True,
-                                          send_messages=True)
+        racethread = await ctx.channel.create_thread(
+            name=name,
+            message=ctx.message,
+            reason="bot generated thread for a multiworld,"
+        )
+
+        race = Race(racethread.id, name, lockable=True)
+        active_races[racethread.id] = race
+        race.channel = racethread
+
         race.message = await ctx.channel.send(
-            "join this multiworld with the following ?join command, @ any"
+            "join this multiworld with the ?join command, @ any"
             + " people that will be on your team if playing coop. "
-            + "Spectate the race with the following ?spectate command\n"
-            + "?join " + str(racechannel.id) + "\n"
-            + "?spectate " + str(racechannel.id))
-        aliases[racechannel.id] = dict()  # for team races
-        teamslist[racechannel.id] = dict()
+        )
+        aliases[racethread.id] = dict()  # for team races
+        teamslist[racethread.id] = dict()
         race.owner = ctx.author.id
 
     @commands.command(aliases=['cr'])
@@ -185,10 +166,9 @@ class Races(commands.Cog):
         try:
             race = active_races[ctx.channel.id]
             race.lockRace()
-            edited_message = "Race: " + race.name \
-                             + " is now locked! Join the race room with the " \
-                               "following command!" \
-                             + "\n?spectate " + str(race.id)
+            edited_message = (
+                "Race: " + race.name + " is now locked! "
+            )
             await race.message.edit(content=edited_message)
             await ctx.channel.send('Race is now locked. New players cannot be added.')
         except RaceNotLockable:
@@ -202,18 +182,16 @@ class Races(commands.Cog):
         race = active_races[ctx.channel.id]
         if (race.islocked):
             race.unlockRace()
-            edited_message = "join this multiworld/race with the following ?join command, @ any" \
-                + " people that will be on your team if playing coop. " \
-                + "Spectate the multiworld/race with the following ?spectate command\n" \
-                + "?join " + str(ctx.channel.id) + "\n" \
-                + "?spectate " + str(ctx.channel.id)
+            edited_message = (
+                "join this multiworld/race with the ?join command, @ any"
+                + " people that will be on your team if playing coop. "
+            )
             await race.message.edit(content=edited_message)
             await ctx.channel.send('This race is now unlocked. New players can join again.')
         else:
             await ctx.channel.send('Race is already unlocked.')
 
     @commands.command(aliases=["enter"])
-    @commands.check(allow_seed_rolling)
     async def join(self, ctx, id=None, name=None):
         try:
             await ctx.message.delete()
@@ -221,15 +199,21 @@ class Races(commands.Cog):
             # Fails on newer discord tokens
             pass
 
+        if ctx.channel.id not in active_races.keys():
+            await ctx.author.send(
+                "Join command must be used in an active race channel or thread"
+            )
+            return
+
         if id is None:
             id = ctx.channel.id
         id = int(id)
         try:
             if active_races[id].started is True:
-                await ctx.channel.send("That race has already started")
+                await ctx.channel.send("This race has already started")
                 return
             if active_races[id].islocked is True:
-                await ctx.channel.send("That race is locked. No new racers can join.")
+                await ctx.channel.send("This race is locked. No new racers can join.")
                 return
         except KeyError:
             await ctx.author.send("That id doesnt exist")
@@ -239,7 +223,6 @@ class Races(commands.Cog):
             name = ctx.author.display_name
 
         race = active_races[id]
-        await ctx.author.add_roles(race.role)
         race.addRunner(ctx.author.id, name)
         aliases[id][ctx.author.id] = ctx.author.id
         teamslist[id][ctx.author.id] = dict(
@@ -248,9 +231,7 @@ class Races(commands.Cog):
         tagpeople = "Welcome! " + ctx.author.mention
         for r in ctx.message.mentions:
             aliases[id][r.id] = ctx.author.id
-            teamslist[id][ctx.author.id]["members"].append(
-                [r.display_name, r.id])
-            await r.add_roles(race.role)
+            teamslist[id][ctx.author.id]["members"].append([r.display_name, r.id])
             tagpeople += r.mention + " "
         await race.channel.send(tagpeople)
 
@@ -296,7 +277,6 @@ class Races(commands.Cog):
         except KeyError:
             return
         await ctx.message.delete()
-        await ctx.author.add_roles(race.role)
         if id:
             await race.channel.send("%s is now cheering you on from the"
                                     + " sidelines" % ctx.author.mention)
@@ -450,23 +430,18 @@ class Races(commands.Cog):
     async def endrace(self, ctx, msg):
         rresults = get(ctx.message.guild.channels, name=constants.race_results)
         await rresults.send(msg + "\n===================================")
-        await ctx.channel.send("deleting this channel in 5 minutes")
-        await asyncio.sleep(300)
-        await self.removeraceroom(ctx)
+        await self.removerace(ctx)
 
     async def startcountdown(self, ctx):
         race = active_races[ctx.channel.id]
         multi = await self.multistream(race, all=True, discord=True, ctx=ctx)
         if (race.readycount != len(race.runners)):
             return
-        edited_message = "Race: " + race.name\
-                         + " has started! Join the race room with the "\
-                           "following command!"\
-                         + "\n?spectate " + str(
-                             race.id) + "\nWatch the race at: "\
-            + (
-                             race.restream if race.restream is not None else
-                             multi)
+        edited_message = (
+            "Race: " + race.name + " has started! "
+            + "\nWatch the race at: "
+            + (race.restream if race.restream is not None else multi)
+        )
         await race.message.edit(content=edited_message)
         for i in range(10):
             await ctx.channel.send(str(10 - i))
@@ -485,30 +460,23 @@ class Races(commands.Cog):
             return
         race.restream = streamid
         await ctx.channel.send("restream set to: " + race.restream)
-        edited_message = ("join this race with the following ?join command,"
-                          + " @ any people that will be on your team if "
-                          + "playing coop. Spectate the race with the "
-                          + "following ?spectate"
-                          + " command\n?join "
-                          + str(race.id)
-                          + "\n?spectate "
-                          + str(race.id)
-                          + "\nWatch the race at: "
-                          + race.restream)
+        edited_message = (
+            "join this race with the ?join command,"
+            + " @ any people that will be on your team if "
+            + "playing coop. "
+            + "\nWatch the race at: "
+            + race.restream
+        )
 
         await race.message.edit(content=edited_message)
 
-    async def removeraceroom(self, ctx, time=0):
+    async def removerace(self, ctx, time=0):
         await asyncio.sleep(time)
         race = active_races[ctx.channel.id]
-        role = race.role
         channel = race.channel
         del active_races[ctx.channel.id]
         del aliases[channel.id]
         del teamslist[channel.id]
-        await channel\
-            .delete(reason="bot deleted channel because the race ended")
-        await role.delete(reason="bot deleted role because the race ended")
 
     @commands.command(
         aliases=["ff1url", "ff1roll", "ffrroll", "rollseedurl", "roll_ffr_url_seed"]


### PR DESCRIPTION
Change race rooms for ?cr and ?ap commands to be based on threads, not channels. Requires changes in https://github.com/FiendsOfTheElements/FFR-Bot/pull/46 due to needing the latest version for Discord.py to handle threads.

Full changes:
- Race rooms will be threads anchored to the ?cr / ?ap message, with the title sent in that argument
- The race message is part of the thread, and is pinned by the bot
- ?spectate command is not used at all, and removed from messages. ?join command works in the thread to join the current race. ?join has been enabled to all channels / rooms, with it being deleted and a personal message sent if used outside of races.
- Threads are just channels with a special type, so all other commands work normally with no changes
- Threads will not be deleted once the race is over. Race results are posted, but the threads will be archived normally after activity stops. This will allow the post race discussion to continue rather than needing to go to the post race / spoiler channel.

Testing
Tested using personal server / bot token. Tested most commands that could be used with just one person. See attached image for output. 
![thread_based_racerooms](https://github.com/user-attachments/assets/e6f0947a-f21d-4499-8d23-428d1d8bba16)
