### PR TITLE
[FEATURE] pin race results and add spoiler tag

### DIFF
--- a/src/ffrrace.py
+++ b/src/ffrrace.py
@@ -66,7 +66,7 @@ class Race:
         self.runners[runnerid]["etime"] = etime
 
         if (all(r["etime"] is not None for r in self.runners.values())):
-            return self.finishRace()
+            return self.finishRace(True)
 
         rval = timedelta(microseconds=round(
             etime - self.runners[runnerid]["stime"], -3) // 1000)
@@ -79,7 +79,7 @@ class Race:
     def forfeit(self, runnerid):
         self.runners[runnerid]["etime"] = maxsize
         if (all(r["etime"] is not None for r in self.runners.values())):
-            return self.finishRace()
+            return self.finishRace(True)
 
         return self.runners[runnerid]["name"] + " forfeited"
 
@@ -106,9 +106,10 @@ class Race:
             return timedelta(microseconds=round(
                 time.perf_counter_ns() - i["stime"], -3) // 1000)
 
-    def finishRace(self):
+    def finishRace(self, spoiler=False):
         rstring = "Race " + self.name + " results:\n\n"
         place = 0
+        rstring += "||" if spoiler else ""
         for runner in sorted(list(self.runners.values()),
                              key=lambda k: k["etime"]):
             place += 1
@@ -118,6 +119,7 @@ class Race:
             else:
                 rstring += str(timedelta(microseconds=round(
                     runner["etime"] - runner["stime"], -3) // 1000)) + "\n"
+        rstring += "||" if spoiler else ""
         return rstring
 
     def lockRace(self):
@@ -136,6 +138,7 @@ class RaceLocked(Exception):
     raised when attempting to add runners to a locked race
     """
     pass
+
 
 class RaceNotLockable(Exception):
     """

--- a/src/races.py
+++ b/src/races.py
@@ -333,8 +333,9 @@ class Races(commands.Cog):
         try:
             race = active_races[ctx.channel.id]
             msg = race.done(aliases[race.id][ctx.author.id])
-            await ctx.channel.send(msg)
+            thread_msg = await ctx.channel.send(msg)
             if (all(r["etime"] is not None for r in race.runners.values())):
+                await thread_msg.pin()  # pin the race results message
                 await self.endrace(ctx, msg)
         except KeyError:
             await ctx.channel.send("Key Error in 'done' command")
@@ -359,8 +360,9 @@ class Races(commands.Cog):
         try:
             race = active_races[ctx.channel.id]
             msg = race.forfeit(aliases[race.id][ctx.author.id])
-            await ctx.channel.send(msg)
+            thread_msg = await ctx.channel.send(msg)
             if (all(r["etime"] is not None for r in race.runners.values())):
+                await thread_msg.pin()  # pin the race results message
                 await self.endrace(ctx, msg)
         except KeyError:
             await ctx.channel.send("Key Error in the 'forfeit' command")


### PR DESCRIPTION
As title. Adding spoiler tags to the race results message so that other runners can do the race async.

TESTING
![spoiler_results](https://github.com/user-attachments/assets/0a505232-0dfd-4c67-b3a3-388a7e994976)
