### PR TITLE
[Bugfix] Removing first argument to the join command

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime, timedelta
 from math import ceil
 from random import random
+import traceback
 from typing import List
 
 import os
@@ -27,7 +28,8 @@ import constants
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s",
     level=logging.INFO,
-    datefmt="%Y-%m-%d %H:%M:%S")
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 intents = discord.Intents.default()
 intents.members = True
@@ -35,19 +37,18 @@ intents.message_content = True
 
 description = "FFR discord bot"
 
-bot = commands.Bot(command_prefix="?", description=description,
-                   case_insensitive=True, intents=intents)
+bot = commands.Bot(
+    command_prefix="?", description=description, case_insensitive=True, intents=intents
+)
 
-redis_pool = redis.ConnectionPool(host=os.environ.get(
-    "REDIS_HOST", "localhost"), port=int(
-    os.environ.get(
-        "REDIS_PORT", "6379")),
-    decode_responses=False)
+redis_pool = redis.ConnectionPool(
+    host=os.environ.get("REDIS_HOST", "localhost"),
+    port=int(os.environ.get("REDIS_PORT", "6379")),
+    decode_responses=False,
+)
 
 redis_races = redis.StrictRedis(connection_pool=redis_pool)
 redis_polls = redis.StrictRedis(connection_pool=redis_pool)
-
-
 
 
 @bot.event
@@ -61,14 +62,25 @@ async def on_ready():
 
 def is_admin(ctx):
     user = ctx.author
-    return (any(role.name in constants.ADMINS for role in user.roles))\
-        or (user.id == int(140605120579764226))
+    return (any(role.name in constants.ADMINS for role in user.roles)) or (
+        user.id == int(140605120579764226)
+    )
 
 
 def allow_seed_rolling(ctx):
-    return (ctx.channel.name == constants.call_for_races_channel) or\
-           (ctx.channel.category_id == get(ctx.guild.categories, name="races")
-            .id)
+    return (ctx.channel.name == constants.call_for_races_channel) or (
+        ctx.channel.category_id == get(ctx.guild.categories, name="races").id
+    )
+
+
+@bot.event
+async def on_command_error(ctx, error):
+    poor_soul = bot.get_user(478735647449022482)
+    if isinstance(error, discord.ext.commands.errors.CommandNotFound):
+        raise error
+    error_msg = "".join(traceback.TracebackException.from_exception(error).format())
+    await poor_soul.send(" ".join(["Error in FFRBot!!\n", error_msg]))
+    raise error
 
 
 @bot.command()
@@ -84,24 +96,23 @@ async def purgemembers(ctx):
 
     if role in user.roles and role.name in constants.adminroles:
         if role.name == constants.challengeseedadmin:
-            role = get(ctx.message.guild.roles,
-                       name=constants.challengeseedrole)
+            role = get(ctx.message.guild.roles, name=constants.challengeseedrole)
         elif role.name == constants.asyncseedadmin:
-            role = get(ctx.message.guild.roles,
-                       name=constants.asyncseedrole)
+            role = get(ctx.message.guild.roles, name=constants.asyncseedrole)
         else:
-            role = get(ctx.message.guild.roles,
-                       name=constants.ducklingrole)
+            role = get(ctx.message.guild.roles, name=constants.ducklingrole)
         members = ctx.message.guild.members
         role_members = [x for x in members if role in x.roles]
 
         for x in role_members:
             await x.remove_roles(role)
     else:
-        await user.send("... Wait a second.. YOU AREN'T AN ADMIN! (note, you"
-                        " need the correct admin role and need to use this"
-                        " in the spoilerchat for the role you want to purge"
-                        " members from)")
+        await user.send(
+            "... Wait a second.. YOU AREN'T AN ADMIN! (note, you"
+            " need the correct admin role and need to use this"
+            " in the spoilerchat for the role you want to purge"
+            " members from)"
+        )
 
     await ctx.message.delete()
 
@@ -116,9 +127,9 @@ async def submit(ctx, runnertime: str = None):
     """
     user = ctx.message.author
     role = await getrole(ctx)
-    if (role.name == constants.ducklingrole and
-            constants.rolerequiredduckling not in
-            [role.name for role in user.roles]):
+    if role.name == constants.ducklingrole and constants.rolerequiredduckling not in [
+        role.name for role in user.roles
+    ]:
         await user.send("You're not a duckling!")
         await ctx.message.delete()
         return
@@ -128,8 +139,11 @@ async def submit(ctx, runnertime: str = None):
         await ctx.message.delete()
         return
 
-    if role is not None and role not in user.roles\
-            and role.name in constants.nonadminroles:
+    if (
+        role is not None
+        and role not in user.roles
+        and role.name in constants.nonadminroles
+    ):
         try:
             # convert to seconds using this method to make sure the time is
             # readable and valid
@@ -137,28 +151,31 @@ async def submit(ctx, runnertime: str = None):
             # still maintain a consistent style on the leaderboard
             t = datetime.strptime(runnertime, "%H:%M:%S")
         except ValueError:
-            await user.send("The time you provided '" + str(runnertime) +
-                            "', this is not in the format HH:MM:SS"
-                            "(or you took a day or longer)")
+            await user.send(
+                "The time you provided '"
+                + str(runnertime)
+                + "', this is not in the format HH:MM:SS"
+                "(or you took a day or longer)"
+            )
             await ctx.message.delete()
             return
 
         await user.add_roles(role)
         delta = timedelta(hours=t.hour, minutes=t.minute, seconds=t.second)
-        username = re.sub('[()-]', '', user.display_name)
+        username = re.sub("[()-]", "", user.display_name)
         leaderboard = await getleaderboard(ctx)
         leaderboard_list = leaderboard.content.split("\n")
 
         # the title is at the start and the forfeit # is after the hyphen at
         # the end of the last line
         title = leaderboard_list[0]
-        forfeits = int(leaderboard_list[-1].split('-')[-1])
+        forfeits = int(leaderboard_list[-1].split("-")[-1])
 
         # trim the leaderboard to remove the title and forfeit message
-        leaderboard_list = leaderboard_list[2:len(leaderboard_list) - 2]
+        leaderboard_list = leaderboard_list[2 : len(leaderboard_list) - 2]
 
         for i in range(len(leaderboard_list)):
-            leaderboard_list[i] = re.split('[)-]', leaderboard_list[i])[1:]
+            leaderboard_list[i] = re.split("[)-]", leaderboard_list[i])[1:]
 
         # convert the time back to hours minutes and seconds for the
         # leaderboard
@@ -167,23 +184,26 @@ async def submit(ctx, runnertime: str = None):
         m = (totsec % 3600) // 60
         s = (totsec % 3600) % 60
 
-        leaderboard_list.append(
-            [" " + username + " ", " %d:%02d:%02d" % (h, m, s)])
+        leaderboard_list.append([" " + username + " ", " %d:%02d:%02d" % (h, m, s)])
 
         # sort the times
-        leaderboard_list.sort(
-            key=lambda x: datetime.strptime(x[1].strip(), "%H:%M:%S"))
+        leaderboard_list.sort(key=lambda x: datetime.strptime(x[1].strip(), "%H:%M:%S"))
 
         # build the string for the leaderboard
         new_leaderboard = title + "\n\n"
         for i in range(len(leaderboard_list)):
-            new_leaderboard += str(i + 1) + ")" +\
-                leaderboard_list[i][0] + "-" +\
-                leaderboard_list[i][1] + "\n"
+            new_leaderboard += (
+                str(i + 1)
+                + ")"
+                + leaderboard_list[i][0]
+                + "-"
+                + leaderboard_list[i][1]
+                + "\n"
+            )
         new_leaderboard += "\nForfeits - " + str(forfeits)
 
         await leaderboard.edit(content=new_leaderboard)
-        await (await getspoilerchat(ctx)).send('GG %s' % user.mention)
+        await (await getspoilerchat(ctx)).send("GG %s" % user.mention)
         await ctx.message.delete()
         await changeparticipants(ctx)
     else:
@@ -216,14 +236,13 @@ async def remove(ctx):
     if channel == challengeseed:
         role = get(roles, name=constants.challengeseedadmin)
         remove_role = get(roles, name=constants.challengeseedrole)
-        participantnumchannel = get(channels,
-                                    name=constants.challengeseedchannel)
+        participantnumchannel = get(channels, name=constants.challengeseedchannel)
     if channel == constants.asyncseed:
         role = get(roles, name=constants.asyncseedadmin)
         remove_role = get(roles, name=constants.asyncseedrole)
         participantnumchannel = get(channels, name=constants.asyncchannel)
     if role in user.roles:
-        leaderboard =  channel.history(limit=100)
+        leaderboard = channel.history(limit=100)
         async for x in leaderboard:
             if bot.user == x.author:
                 leaderboard = x
@@ -234,13 +253,13 @@ async def remove(ctx):
         # the title is at the start and the forfeit # is after the hyphen at
         # the end of the last line
         title = leaderboard_list[0]
-        forfeits = int(leaderboard_list[-1].split('-')[-1])
+        forfeits = int(leaderboard_list[-1].split("-")[-1])
 
         # trim the leaderboard to remove the title and forfeit message
-        leaderboard_list = leaderboard_list[2:len(leaderboard_list) - 2]
+        leaderboard_list = leaderboard_list[2 : len(leaderboard_list) - 2]
 
         for i in range(len(leaderboard_list)):
-            leaderboard_list[i] = re.split('[)-]', leaderboard_list[i])[1:]
+            leaderboard_list[i] = re.split("[)-]", leaderboard_list[i])[1:]
 
         players = ctx.message.mentions
         if not players:
@@ -251,14 +270,14 @@ async def remove(ctx):
         for player in players:
             i = 0
             for i in range(len(leaderboard_list)):
-                if leaderboard_list[i][0][1:len(
-                        leaderboard_list[i][0]) - 1] == re.sub('[()-]', '',
-                                                               player
-                                                               .display_name):
+                if leaderboard_list[i][0][
+                    1 : len(leaderboard_list[i][0]) - 1
+                ] == re.sub("[()-]", "", player.display_name):
                     del leaderboard_list[i]
                     await player.remove_roles(remove_role)
-                    await changeparticipants(ctx, increment=False,
-                                             channel=participantnumchannel)
+                    await changeparticipants(
+                        ctx, increment=False, channel=participantnumchannel
+                    )
                     break
 
         # should already be sorted
@@ -268,9 +287,14 @@ async def remove(ctx):
         # build the string for the leaderboard
         new_leaderboard = title + "\n\n"
         for i in range(len(leaderboard_list)):
-            new_leaderboard += str(i + 1) + ")" +\
-                leaderboard_list[i][0] + "-" +\
-                leaderboard_list[i][1] + "\n"
+            new_leaderboard += (
+                str(i + 1)
+                + ")"
+                + leaderboard_list[i][0]
+                + "-"
+                + leaderboard_list[i][1]
+                + "\n"
+            )
         new_leaderboard += "\nForfeits - " + str(forfeits)
 
         await leaderboard.edit(content=new_leaderboard)
@@ -295,30 +319,36 @@ async def createleaderboard(ctx, name):
 
     # gross way of doing this, works for now
     if role in user.roles and role.name == constants.challengeseedadmin:
-        await get(ctx.message.guild.channels,
-                  name=constants.challengeseedleaderboard)\
-            .send(name + "\n\nForfeits - 0")
-        await get(ctx.message.guild.channels,
-                  name=constants.challengeseedchannel)\
-            .send("Number of participants: 0")
+        await get(
+            ctx.message.guild.channels, name=constants.challengeseedleaderboard
+        ).send(name + "\n\nForfeits - 0")
+        await get(ctx.message.guild.channels, name=constants.challengeseedchannel).send(
+            "Number of participants: 0"
+        )
 
     elif role in user.roles and role.name == constants.asyncseedadmin:
-        await get(ctx.message.guild.channels,
-                  name=constants.asyncleaderboard)\
-            .send(name + "\n\nForfeits - 0")
-        await get(ctx.message.guild.channels, name=constants.asyncchannel)\
-            .send("Number of participants: 0")
+        await get(ctx.message.guild.channels, name=constants.asyncleaderboard).send(
+            name + "\n\nForfeits - 0"
+        )
+        await get(ctx.message.guild.channels, name=constants.asyncchannel).send(
+            "Number of participants: 0"
+        )
 
     elif role in user.roles and role.name == constants.ducklingadminrole:
-        await get(ctx.message.guild.channels,
-                  name=constants.ducklingleaderboard)\
-            .send(name + "\n\nForfeits - 0")
-        await get(ctx.message.guild.channels, name=constants.ducklingchannel)\
-            .send("Number of participants: 0")
+        await get(ctx.message.guild.channels, name=constants.ducklingleaderboard).send(
+            name + "\n\nForfeits - 0"
+        )
+        await get(ctx.message.guild.channels, name=constants.ducklingchannel).send(
+            "Number of participants: 0"
+        )
 
     else:
-        await user.send(("... Wait a second.. YOU AREN'T AN ADMIN! (note, you"
-                         " need the admin role for this channel)"))
+        await user.send(
+            (
+                "... Wait a second.. YOU AREN'T AN ADMIN! (note, you"
+                " need the admin role for this channel)"
+            )
+        )
 
     await ctx.message.delete()
 
@@ -334,8 +364,11 @@ async def ff(ctx):
     user = ctx.message.author
     role = await getrole(ctx)
 
-    if role is not None and role not in user.roles\
-            and role.name in constants.nonadminroles:
+    if (
+        role is not None
+        and role not in user.roles
+        and role.name in constants.nonadminroles
+    ):
 
         await user.add_roles(role)
         leaderboard = await getleaderboard(ctx)
@@ -426,16 +459,15 @@ async def getleaderboard(ctx):
     ducklingseed = get(channels, name=constants.ducklingchannel)
 
     if channel == challengeseed:
-        leaderboard =  get(
-            channels,
-            name=constants.challengeseedleaderboard).history(
-            limit=100)
+        leaderboard = get(channels, name=constants.challengeseedleaderboard).history(
+            limit=100
+        )
     elif channel == asyncseed:
-        leaderboard =  get(channels, name=constants.asyncleaderboard).history(limit=100)
+        leaderboard = get(channels, name=constants.asyncleaderboard).history(limit=100)
     elif channel == ducklingseed:
-        leaderboard =  get(channels,
-                                name=constants.ducklingleaderboard).history(
-            limit=100)
+        leaderboard = get(channels, name=constants.ducklingleaderboard).history(
+            limit=100
+        )
     else:
         await user.send("That command isn't allowed here.")
         return None
@@ -484,7 +516,9 @@ async def changeparticipants(ctx, increment=True, channel=None):
     :return: None
     """
 
-    participants: List[Message] = (ctx.message.channel if channel is None else channel).history(limit=100)
+    participants: List[Message] = (
+        ctx.message.channel if channel is None else channel
+    ).history(limit=100)
     async for x in participants:
         if x.author == bot.user:
             participants = x
@@ -505,6 +539,7 @@ async def changeparticipants(ctx, increment=True, channel=None):
 #     channel = ctx.message.channel
 #     await bot.purge_from(channel, limit=100000)
 
+
 @bot.command()
 async def whoami(ctx):
     await ctx.author.send(ctx.author.id)
@@ -516,9 +551,10 @@ async def roll(ctx, dice):
     match = re.match(r"((\d{1,3})?d\d{1,9})", dice)
     if match is None:
         await ctx.message.channel.send(
-            "Roll arguments must be in the form [N]dM ie. 3d6, d8")
+            "Roll arguments must be in the form [N]dM ie. 3d6, d8"
+        )
         return
-    rollargs = match.group().split('d')
+    rollargs = match.group().split("d")
 
     try:
         rollargs[0] = int(rollargs[0])
@@ -567,7 +603,8 @@ async def main(client, token):
     async with client:
         await client.start(token)
 
-with open('token.txt', 'r') as f:
+
+with open("token.txt", "r") as f:
     token = f.read()
 token = token.strip()
 

--- a/src/races.py
+++ b/src/races.py
@@ -192,7 +192,7 @@ class Races(commands.Cog):
             await ctx.channel.send('Race is already unlocked.')
 
     @commands.command(aliases=["enter"])
-    async def join(self, ctx, id=None, name=None):
+    async def join(self, ctx, name=None):
         try:
             await ctx.message.delete()
         except DiscordException:
@@ -205,9 +205,7 @@ class Races(commands.Cog):
             )
             return
 
-        if id is None:
-            id = ctx.channel.id
-        id = int(id)
+        id = int(ctx.channel.id)
         try:
             if active_races[id].started is True:
                 await ctx.channel.send("This race has already started")


### PR DESCRIPTION
Changes to the join command when switching to threads means that the first argument isn't used. Need to remove it from the call as well as the handling code, since the `?join @teammate` breaks. 

This also applies formatting to the main.py file. Added an error handler that will message me when the bot commands don't work.