### PR TITLE
Various bugfixes and formatting

### DIFF
--- a/src/ffrrace.py
+++ b/src/ffrrace.py
@@ -1,8 +1,8 @@
 import time
 from datetime import timedelta
 from sys import maxsize
-import redis
 import os
+import redis
 
 redis_db = redis.Redis(host=os.environ.get("REDIS_HOST", "localhost"),
                        port=int(os.environ.get("REDIS_PORT", "6379")))
@@ -91,8 +91,8 @@ class Race:
                 if (runner["etime"] is maxsize):
                     rval += "forfeited"
                 elif (runner["etime"] is not None):
-                    time = self._getTimeDeltaStr(runner["etime"], runner["stime"])
-                    rval += "done: " + time
+                    runner_time = self._getTimeDeltaStr(runner["etime"], runner["stime"])
+                    rval += "done: " + runner_time
                 else:
                     rval += "still going"
             else:

--- a/src/races.py
+++ b/src/races.py
@@ -156,8 +156,8 @@ class Races(commands.Cog):
     @commands.check(is_race_owner)
     @commands.check(is_race_room)
     async def closerace(self, ctx):
-        await ctx.channel.send("deleting this race in 5 minutes")
-        await self.removeraceroom(ctx, 300)
+        await ctx.channel.send("locking and archiving this race")
+        await self.lockracethread(ctx)
 
     @commands.command()
     @is_race_started(toggle=False)
@@ -497,6 +497,10 @@ class Races(commands.Cog):
         del aliases[channel.id]
         del teamslist[channel.id]
 
+    async def lockracethread(self, ctx):
+        await ctx.channel.edit(locked=True, archived=True)
+        await self.removerace(ctx)
+
     @commands.command(
         aliases=["ff1url", "ff1roll", "ffrroll", "rollseedurl", "roll_ffr_url_seed"]
     )
@@ -653,10 +657,10 @@ class Races(commands.Cog):
         await self.startcountdown(ctx)
 
     @commands.command()
-    @commands.check(is_admin)
+#    @commands.check(is_admin)
     @commands.check(is_race_room)
     async def forceclose(self, ctx):
-        await self.removeraceroom(ctx)
+        await self.lockracethread(ctx)
 
     @commands.command()
     @commands.check(is_admin)

--- a/src/races.py
+++ b/src/races.py
@@ -96,7 +96,7 @@ class Races(commands.Cog):
         for k, v in temp_twitchids.items():
             self.twitchids[k.decode("utf-8")] = v.decode("utf-8")
         logging.info("Loading saved Twitch ids")
-        logging.debug("twitch ids:" + str(self.twitchids))
+        logging.debug("twitch ids: %s", str(self.twitchids))
 
     @commands.command(aliases=["sr"])
     @commands.check(is_call_for_races)
@@ -247,6 +247,17 @@ class Races(commands.Cog):
 
         if race.runners[ctx.author.id]["ready"] is True:
             race.readycount -= 1
+
+        if race.started:
+            # quiting a started race is akin to forfeit
+            await self.forfeit(ctx)
+            await ctx.channel.send(
+                ctx.author.display_name
+                + " has left the race and is now cheering "
+                + "from the sidelines."
+            )
+            return
+
         race.removeRunner(ctx.author.id)
         await ctx.channel.send(
             ctx.author.display_name
@@ -278,7 +289,7 @@ class Races(commands.Cog):
         await ctx.message.delete()
         if id:
             await race.channel.send(
-                "%s is now cheering you on from the" + " sidelines" % ctx.author.mention
+                f"{ctx.author.mention} is now cheering you on from the sidelines"
             )
 
     @commands.command(aliases=["r"])

--- a/src/races.py
+++ b/src/races.py
@@ -657,7 +657,7 @@ class Races(commands.Cog):
         for runner in race.runners.keys():
             if race.runners[runner]["etime"] is None:
                 race.forfeit(runner)
-        results = race.finishRace()
+        results = race.getFinishedRaceMessage()
         await self.endrace(ctx, results)
 
     @commands.command()

--- a/src/races.py
+++ b/src/races.py
@@ -235,7 +235,6 @@ class Races(commands.Cog):
         await race.channel.send(tagpeople)
 
     @commands.command(aliases=["quit"])
-    @is_race_started(toggle=False)
     @is_runner()
     @commands.check(is_race_room)
     async def unjoin(self, ctx):


### PR DESCRIPTION
Applied black formatting from races.py and ffrrace.py. This is the first commit and appears to change the entire file, which is a bummer for PR review. However, there's no functional change in that commit.

The remaining fixes:
- Fix `forceend` to properly end the race and print the race results message
- Changed behaviour for quit, allowing it be called after the race has started and basically be an alias for forfeit
- Fixed `closerace` and `forceclose` to archive and lock the thread when called

TESTING

Tested locally using private discord server. All commands work as expected.