### PR TITLE
Breaking up list roles into two messages

### DIFF
--- a/src/roles.py
+++ b/src/roles.py
@@ -63,8 +63,8 @@ class Roles(commands.Cog):
                                  zip(constants
                                      .self_assignable_roles,
                                      constants.
-                                     self_assignable_roles_descriptions)])
-                  + '\n\n\nCommands:\n\n use ?addrole'
+                                     self_assignable_roles_descriptions)]))
+        await ctx.author.send('\n\nCommands:\n\n use ?addrole'
                   + ' "rolename" in role-requests'
                   + " to add yourself to a role, or you can"
                   + '\n\n use ?removerole "rolename" to remove it.')


### PR DESCRIPTION
Adding the new role and description made the message too long to send as one chunk (2000 characters). Splitting the listroles command into two messages to avoid the restriction.