### PR TITLE
Report

### DIFF
--- a/src/cogs/report.py
+++ b/src/cogs/report.py
@@ -1,0 +1,105 @@
+import random
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+from discord.interactions import Interaction
+
+import constants
+
+class OpenReportThread(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=60)
+
+    @discord.ui.button(label="Yes", style=discord.ButtonStyle.red, row=2)
+    async def yes(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(OpenReportModal())
+
+class OpenReportModal(discord.ui.Modal, title="Open Report"):
+    description = discord.ui.TextInput(
+        label="Summary",
+        placeholder="Please provide a brief summary of your report to help the moderation team understand the issue.",
+        min_length=10,
+        max_length=200,
+        required=True,
+        row=1,
+    )
+
+    def __init__(self):
+        super().__init__()
+
+    async def on_submit(self, interaction: Interaction) -> None:
+        duration = 24 * 60
+
+        msg = None
+        thread: discord.Thread = await interaction.channel.create_thread(
+            name=f"Report {interaction.user.name} {random.randint(0, 999)}", message=msg,
+            auto_archive_duration=duration)
+
+        pinged_members = discord.utils.get(interaction.guild.roles, name=constants.mod_role).members + discord.utils.get(interaction.guild.roles, name=constants.admin_role).members
+        await thread.add_user(interaction.user)
+        await interaction.response.send_message(
+            f"A new thread called {thread.mention} has been opened for this report.", ephemeral=True)
+
+        if interaction.guild.chunked is False:
+            await interaction.guild.chunk(cache=True)
+
+        for member in pinged_members:
+            await thread.add_user(member)
+
+        await thread.send(
+            f"{interaction.user.mention} has opened an report.\n\n**Description:** {self.description.value}",
+            allowed_mentions=discord.AllowedMentions.none()
+        )
+
+class Report(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.persistent_views_added = False
+
+    @app_commands.command(description="Adds a message that allows users to create a private thread to open an report.")
+    async def report(
+            self,
+            interaction: discord.Interaction,
+    ):
+        """
+        Adds a message that allows users to create a private thread to open an report.
+        """
+        if not interaction.channel.permissions_for(interaction.user).manage_threads:
+            await interaction.response.send_message("You must have manage threads permission to use this feature.",
+                                                    ephemeral=True)
+            return
+
+        if not interaction.channel.permissions_for(interaction.guild.me).create_private_threads:
+            await interaction.response.send_message(
+                "This bot needs permission to create private threads in this channel.", ephemeral=True)
+            return
+
+        if interaction.channel.permissions_for(interaction.guild.default_role).send_messages:
+            await interaction.response.send_message(
+                "`@everyone` should not be allowed to send messages in this channel.", ephemeral=True)
+            return
+
+        if not interaction.channel.permissions_for(interaction.guild.default_role).send_messages_in_threads:
+            await interaction.response.send_message(
+                    "`@everyone` needs to be able to send messages in threads.", ephemeral=True
+                )
+            return
+
+        mod_role = discord.utils.get(interaction.guild.roles, name=constants.mod_role)
+        admin_role = discord.utils.get(interaction.guild.roles, name=constants.admin_role)
+        if not mod_role or not admin_role:
+            await interaction.response.send_message(
+                "The server must have a mod and admin role for this feature to work.", ephemeral=True)
+            return
+        
+        await interaction.response.send_message(
+            content=(
+                f"This will open a private thread to {mod_role.mention} and {admin_role.mention}, are you sure you want to do that?\n\n"
+                "This message will stop working after one minute.\n"
+                "If you did not intend to do this, simply click \"Dismiss message\" at the bottom of this response. Thanks!"
+            ),
+            ephemeral=True,
+            view=OpenReportThread(),
+            allowed_mentions=discord.AllowedMentions(roles=False)
+        )

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,6 @@
 ADMINS = ["admin", "dev admin", "arbiter"]
+mod_role = "moderator"
+admin_role = "admin"
 Sleep_Time = 5000
 ducklingchannel = 'duckling-weekly'
 ducklingleaderboard = 'duckling-leaderboard'

--- a/src/main.py
+++ b/src/main.py
@@ -55,12 +55,9 @@ redis_polls = redis.StrictRedis(connection_pool=redis_pool)
 @bot.event
 async def on_ready():
     await bot.tree.sync()
-    logging.info("Commands synced globally.")
     for guild in bot.guilds:
-        logging.info("Syncing commands for guild: %s (ID: %s)", guild.name, guild.id)
         cmds = bot.tree.get_commands(guild=guild)
         if cmds:
-            logging.info("Loaded %d commands for %s", len(cmds), guild.name)
             await bot.tree.sync(guild=guild)
 
     logging.info("discord.py version: %s", discord.__version__)

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ import discord
 from races import Races
 from roles import Roles
 from voting.polls import Polls
+from cogs.report import Report
 
 import constants
 
@@ -53,7 +54,16 @@ redis_polls = redis.StrictRedis(connection_pool=redis_pool)
 
 @bot.event
 async def on_ready():
-    logging.info("discord.py version: " + discord.__version__)
+    await bot.tree.sync()
+    logging.info("Commands synced globally.")
+    for guild in bot.guilds:
+        logging.info("Syncing commands for guild: %s (ID: %s)", guild.name, guild.id)
+        cmds = bot.tree.get_commands(guild=guild)
+        if cmds:
+            logging.info("Loaded %d commands for %s", len(cmds), guild.name)
+            await bot.tree.sync(guild=guild)
+
+    logging.info("discord.py version: %s", discord.__version__)
     logging.info("Logged in as")
     logging.info(bot.user.name)
     logging.info(bot.user.id)
@@ -599,7 +609,7 @@ async def main(client, token):
     await bot.add_cog(Races(bot, redis_races))
     await bot.add_cog(Roles(bot))
     await bot.add_cog(Polls(bot, redis_polls))
-
+    await bot.add_cog(Report(bot))
     async with client:
         await client.start(token)
 


### PR DESCRIPTION
Creating a command that allows users to start a private "report" thread with the moderator and the admin team. All command messages are shown only to the user who invokes the command, and the private thread is created with just the user and the admins. This should allow users to create reports without having to indicate that they are doing so, and provide a better way to contact the admin team about an issue without having to use DMs.