### PR TITLE
Hybrid commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ chardet==3.0.4
 pymongo==3.11.0
 discord.py==2.4.0
 redis~=5.0.8
+pytz==2026.2

--- a/src/cogs/misc.py
+++ b/src/cogs/misc.py
@@ -2,6 +2,7 @@ import re
 from math import ceil
 from random import random
 from discord.ext import commands
+import constants
 
 class MiscCommandCog(commands.Cog):
     def __init__(self, bot):
@@ -13,6 +14,17 @@ class MiscCommandCog(commands.Cog):
         await ctx.author.send(ctx.author.id)
         await ctx.message.delete()
 
+    @commands.command()
+    async def sync(self, ctx, context=None):
+        if (ctx.author.id != constants.poor_soul_id):
+            await ctx.author.send("You don't have permission to use this command.")
+            return
+        
+        await self.bot.tree.sync(guild=ctx.guild)    
+        await ctx.author.send("Synced commands for this guild")
+        if context == "*":
+            await self.bot.tree.sync()
+            await ctx.author.send("Synced commands globally")
 
     @commands.command()
     async def roll(self, ctx, dice):

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -16,6 +16,22 @@ import constants
 from cogs.races.async_race import AsyncRace
 from cogs.global_checks import is_admin
 
+async def coop_autocomplete(
+    interaction: discord.Interaction, 
+    current: str
+) -> list[app_commands.Choice[str]]:
+    # Create the text choices you want to provide
+    options = [
+        {"name": "Enabled (True)", "value": "true"},
+        {"name": "Disabled (False)", "value": "false"}
+    ]
+    
+    # Filter choices dynamically based on what the user types
+    return [
+        app_commands.Choice(name=opt["name"], value=opt["value"])
+        for opt in options if current.lower() in opt["name"].lower()
+    ]
+
 class StartAsyncFlags(commands.FlagConverter):
     name: str
     flags: str
@@ -24,43 +40,42 @@ class StartAsyncFlags(commands.FlagConverter):
     end_timestamp: Optional[int]
     coop: Optional[bool] = False
 
-
 class CreateAsyncModal(ui.Modal):
     """Modal for creating a new async race with guided form inputs."""
-    
-    title = "Create Async Race"
-    
-    name_input = ui.TextInput(
-        label="Race Name",
-        placeholder="e.g., Tournament Race 1",
-        required=True
-    )
-    flags_input = ui.TextInput(
-        label="Race Flags",
-        placeholder="Flag URL",
-        required=True,
-        style=discord.TextStyle.long
-    )
-    race_role_input = ui.TextInput(
-        label="Role Name (optional)",
-        placeholder="Leave blank if not needed",
-        required=False
-    )
-    start_time_input = ui.TextInput(
-        label="Start Time (optional, ISO format, Eastern time)",
-        placeholder="e.g., 2026-07-15T10:30:00",
-        required=False
-    )
-    end_time_input = ui.TextInput(
-        label="End Time (optional, ISO format, Eastern time)",
-        placeholder="e.g., 2026-07-15T12:00:00",
-        required=False
-    )
-    coop_input = ui.TextInput(
-        label="Co-op Mode (optional)",
-        placeholder="true or false (default: false)",
-        required=False
-    )
+    def __init__(self, cog, coop_mode: bool = False):    
+        super().__init__(title="Create Async Race")
+        self.coop_mode = coop_mode    
+        self.name_input = ui.TextInput(
+            label="Race Name",
+            placeholder="e.g., Tournament Race 1",
+            required=True
+        )
+        self.flags_input = ui.TextInput(
+            label="Race Flags",
+            placeholder="Flag URL",
+            required=True,
+            style=discord.TextStyle.long
+        )
+        self.race_role_input = ui.TextInput(
+            label="Role Name (optional)",
+            placeholder="Leave blank if not needed",
+            required=False
+        )
+        self.start_time_input = ui.TextInput(
+            label="Start Time (optional, ISO format, Eastern)",
+            placeholder="e.g., 2026-07-15T10:30:00",
+            required=False
+        )
+        self.end_time_input = ui.TextInput(
+            label="End Time (optional, ISO format, Eastern)",
+            placeholder="e.g., 2026-07-15T12:00:00",
+            required=False
+        )
+        self.add_item(self.name_input)
+        self.add_item(self.flags_input)
+        self.add_item(self.race_role_input)
+        self.add_item(self.start_time_input)
+        self.add_item(self.end_time_input)        
 
     def _iso_to_unix_timestamp(self, iso_string: str) -> Optional[int]:
         """
@@ -86,11 +101,6 @@ class CreateAsyncModal(ui.Modal):
         
     async def on_submit(self, interaction: discord.Interaction):
         """Process modal submission."""
-        # Check admin permission first
-        if not is_admin(interaction.user):
-            await interaction.response.defer()
-            await interaction.user.send("You do not have permission to create async races right now")
-            return
 
         # Extract and parse inputs
         name = self.name_input.value.strip() if self.name_input.value else None
@@ -98,7 +108,6 @@ class CreateAsyncModal(ui.Modal):
         race_role = self.race_role_input.value.strip() if self.race_role_input.value else None
         start_time_iso = self.start_time_input.value.strip() if self.start_time_input.value else None
         end_time_iso = self.end_time_input.value.strip() if self.end_time_input.value else None
-        coop_str = self.coop_input.value.strip().lower() if self.coop_input.value else None
 
         # Validate required fields
         if not name:
@@ -110,12 +119,6 @@ class CreateAsyncModal(ui.Modal):
             await interaction.response.defer()
             await interaction.user.send("You did not submit flags.")
             return
-
-        # Parse coop boolean
-        coop = False
-        if coop_str:
-            if coop_str.lower() in ("true", "yes", "1"):
-                coop = True
 
         # Parse timestamps
         start_timestamp = None
@@ -143,6 +146,9 @@ class CreateAsyncModal(ui.Modal):
                 await interaction.user.send(f"The role '{race_role}' does not exist.")
                 return
 
+        # defer now to be able to create in time.
+        await interaction.response.defer(ephemeral=True)
+
         # Create the race
         try:
             race = AsyncRace(
@@ -161,21 +167,19 @@ class CreateAsyncModal(ui.Modal):
                     else None
                 ),
                 race_role,
-                coop,
+                self.coop_mode,
             )
 
             await race.init_race()
             self.cog.active_races[race.race_id] = race
             self.cog._save_one(race)
 
-            await interaction.response.defer()
-            await interaction.user.send(f"✅ Async race '{name}' created successfully!")
+            await interaction.followup.send(f"✅ Async race '{name}' created successfully!", ephemeral=True)
         except Exception as e:
-            await interaction.response.defer()
             error_msg = f"Error creating race: {str(e)}"
             logging.error(error_msg)
             logging.exception(e)
-            await interaction.user.send(error_msg)
+            await interaction.followup.send(error_msg, ephemeral=True)
 
 
 class AsyncRaces(commands.Cog):
@@ -205,17 +209,28 @@ class AsyncRaces(commands.Cog):
         del self.active_races[race.race_id]
         self._delete_one(race.race_id)
 
-
-
     @app_commands.command(name="createasync", description="Create a new async race using a guided form")
-    async def createasync(self, interaction: discord.Interaction):
+    @app_commands.describe(coop="Is this a co-op race? (Default: false)")
+    @app_commands.autocomplete(coop=coop_autocomplete) 
+    async def createasync(self, interaction: discord.Interaction, coop: str = "false"):
         """
         Creates a new async race via a modal form.
         Shows a modal to guide the user through entering race details.
         """
-        modal = CreateAsyncModal()
+        # Check admin permission first
+        if not is_admin(interaction.user):
+            await interaction.response.defer()
+            await interaction.user.send("You do not have permission to create async races right now")
+            return
+        
+        if coop.lower() not in ["true", "false"]:
+            await interaction.response.defer()
+            await interaction.response.send_message("Invalid value for coop. Use 'true' or 'false'.", ephemeral=True)
+            return
+        
+        modal = CreateAsyncModal(self, coop_mode=coop.lower() == "true")
         modal.cog = self
-        await interaction.response.show_modal(modal)
+        await interaction.response.send_modal(modal)
 
 
     @commands.command()
@@ -316,7 +331,9 @@ class AsyncRaces(commands.Cog):
         """
         Submits a runners time to an async race
         :param runnertime: time of the runner, in the format H:M:S, e.g. 2:32:12
-        :param vod: link to the vod of the run, required for tournament asyncs
+        :param vod: optional link to the vod of the run, required for tournament asyncs
+        :param teammate: optional discord member for co-op asyncs
+        :param teammate_vod: optional link to the teammate's vod for co-op asyncs
         :param ctx: context of the command
         :return: None
         """
@@ -329,7 +346,10 @@ class AsyncRaces(commands.Cog):
             await race.submit(ctx.author, runnertime, vod, False, teammate, teammate_vod)
             self._save_one(race)
 
-        await ctx.message.delete()
+        if ctx.interaction:
+            await ctx.interaction.response.defer(thinking=False)
+        else:
+            await ctx.message.delete()
 
 
     async def submit_leaderboard(self, ctx, runnertime):
@@ -577,7 +597,10 @@ class AsyncRaces(commands.Cog):
         if (race is not None):
             await race.submit(ctx.author, "00:00:00", "", True, teammate)
             self._save_one(race)
-            await ctx.message.delete()
+            if ctx.interaction:
+                await ctx.interaction.response.defer(thinking=False)
+            else:                 
+                await ctx.message.delete()
             return
 
         user = ctx.message.author
@@ -599,7 +622,10 @@ class AsyncRaces(commands.Cog):
             await leaderboard.edit(content=new_leaderboard)
             await self.changeparticipants(ctx)
 
-        await ctx.message.delete()
+        if ctx.interaction:
+            await ctx.interaction.response.defer(thinking=False)
+        else:                 
+            await ctx.message.delete()
 
 
     async def spectate(self, ctx):
@@ -612,14 +638,20 @@ class AsyncRaces(commands.Cog):
         if (race is not None):
             await race.spectate(ctx.author)
             self._save_one(race)
-            await ctx.message.delete()
+            if ctx.interaction:
+                await ctx.interaction.response.defer(thinking=False)
+            else:                 
+                await ctx.message.delete()
             return 
         
         user = ctx.message.author
         role = await self.getrole(ctx)
         if role is not None and role.name in constants.nonadminroles:
             await user.add_roles(role)
-        await ctx.message.delete()
+        if ctx.interaction:
+            await ctx.interaction.response.defer(thinking=False)
+        else:                 
+            await ctx.message.delete()
 
 
     async def getrole(self, ctx):

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -204,6 +204,9 @@ class AsyncRaces(commands.Cog):
         del self.active_races[race.race_id]
         self._delete_one(race.race_id)
 
+    def is_async_race_crew_member(self, user):
+        return is_admin(user) or any(role.name in constants.adminroles + ["Race Crew Lead"] for role in user.roles)
+
     @app_commands.command(name="createasync", description="Create a new async race using a guided form")
     @app_commands.describe(coop="Is this a co-op race? (Default: false)")
     @app_commands.autocomplete(coop=coop_autocomplete) 
@@ -213,7 +216,7 @@ class AsyncRaces(commands.Cog):
         Shows a modal to guide the user through entering race details.
         """
         # Check admin permission first
-        if not is_admin(interaction.user):
+        if not self.is_async_race_crew_member(interaction.user):
             await interaction.response.send_message("You do not have permission to create async races right now", ephemeral=True)
             return
         
@@ -260,6 +263,7 @@ class AsyncRaces(commands.Cog):
 
         await race.end_race()
         self.remove_race(race)
+        await ctx.message.delete()
     
     @commands.command(aliases=["cancel"])
     async def cancelasync(self, ctx):

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -194,7 +194,7 @@ class AsyncRaces(commands.Cog):
 
         await ctx.message.delete()
 
-    @commands.hybrid_command()
+    @commands.hybrid_command(description="Submit your time alongside a VOD for the async race.")
     async def submit(self, ctx, runnertime: str | None = None, vod: str | None = None, teammate: discord.Member = None, teammate_vod: str | None = None):
         """
         Submits a runners time to an async race

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -337,6 +337,9 @@ class AsyncRaces(commands.Cog):
         :param ctx: context of the command
         :return: None
         """
+        if ctx.interaction:
+            await ctx.defer(ephemeral=True)
+            
         # check to see if this was submitted to an active race
         race = self.get_race(ctx.channel.id)
         if race is None:
@@ -347,7 +350,7 @@ class AsyncRaces(commands.Cog):
             self._save_one(race)
 
         if ctx.interaction:
-            await ctx.interaction.response.defer(thinking=False)
+            await ctx.interaction.delete_original_response()
         else:
             await ctx.message.delete()
 
@@ -593,12 +596,15 @@ class AsyncRaces(commands.Cog):
         :param ctx: context of the command
         :return: None
         """
+        if ctx.interaction:
+            await ctx.defer(ephemeral=True)
+
         race = self.get_race(ctx.channel.id)
         if (race is not None):
             await race.submit(ctx.author, "00:00:00", "", True, teammate)
             self._save_one(race)
             if ctx.interaction:
-                await ctx.interaction.response.defer(thinking=False)
+                await ctx.interaction.delete_original_response()
             else:                 
                 await ctx.message.delete()
             return
@@ -623,7 +629,7 @@ class AsyncRaces(commands.Cog):
             await self.changeparticipants(ctx)
 
         if ctx.interaction:
-            await ctx.interaction.response.defer(thinking=False)
+            await ctx.interaction.delete_original_response()
         else:                 
             await ctx.message.delete()
 
@@ -634,12 +640,15 @@ class AsyncRaces(commands.Cog):
         :param ctx: context of the command
         :return: None
         """
+        if ctx.interaction:
+            await ctx.defer(ephemeral=True)
+
         race = self.get_race(ctx.channel.id)
         if (race is not None):
             await race.spectate(ctx.author)
             self._save_one(race)
             if ctx.interaction:
-                await ctx.interaction.response.defer(thinking=False)
+                await ctx.interaction.delete_original_response()
             else:                 
                 await ctx.message.delete()
             return 
@@ -649,7 +658,7 @@ class AsyncRaces(commands.Cog):
         if role is not None and role.name in constants.nonadminroles:
             await user.add_roles(role)
         if ctx.interaction:
-            await ctx.interaction.response.defer(thinking=False)
+            await ctx.interaction.delete_original_response()
         else:                 
             await ctx.message.delete()
 

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -8,7 +8,9 @@ from typing import List, Optional
 
 import discord
 from discord.ext import commands
+from discord import app_commands, ui
 from discord.utils import get
+import pytz
 
 import constants
 from cogs.races.async_race import AsyncRace
@@ -21,7 +23,160 @@ class StartAsyncFlags(commands.FlagConverter):
     start_timestamp: Optional[int]
     end_timestamp: Optional[int]
     coop: Optional[bool] = False
-# 
+
+
+class CreateAsyncModal(ui.Modal):
+    """Modal for creating a new async race with guided form inputs."""
+    
+    title = "Create Async Race"
+    
+    name_input = ui.TextInput(
+        label="Race Name",
+        placeholder="e.g., Tournament Race 1",
+        required=True
+    )
+    flags_input = ui.TextInput(
+        label="Race Flags",
+        placeholder="Flag URL",
+        required=True,
+        style=discord.TextStyle.long
+    )
+    race_role_input = ui.TextInput(
+        label="Role Name (optional)",
+        placeholder="Leave blank if not needed",
+        required=False
+    )
+    start_time_input = ui.TextInput(
+        label="Start Time (optional, ISO format, Eastern time)",
+        placeholder="e.g., 2026-07-15T10:30:00",
+        required=False
+    )
+    end_time_input = ui.TextInput(
+        label="End Time (optional, ISO format, Eastern time)",
+        placeholder="e.g., 2026-07-15T12:00:00",
+        required=False
+    )
+    coop_input = ui.TextInput(
+        label="Co-op Mode (optional)",
+        placeholder="true or false (default: false)",
+        required=False
+    )
+
+    def _iso_to_unix_timestamp(self, iso_string: str) -> Optional[int]:
+        """
+        Converts an ISO format datetime string (Eastern time) to Unix timestamp.
+        
+        Args:
+            iso_string: ISO format string, e.g., "2026-07-15T10:30:00"
+        
+        Returns:
+            Unix timestamp (int) if parsing succeeds, None otherwise
+        """
+        try:
+            # Parse ISO format
+            dt = datetime.fromisoformat(iso_string)
+            # Assume the input is in Eastern time
+            eastern = pytz.timezone('America/New_York')
+            dt_eastern = eastern.localize(dt)
+            # Convert to Unix timestamp
+            timestamp = int(dt_eastern.timestamp())
+            return timestamp
+        except (ValueError, pytz.exceptions.NonExistentTimeError, pytz.exceptions.AmbiguousTimeError):
+            return None
+        
+    async def on_submit(self, interaction: discord.Interaction):
+        """Process modal submission."""
+        # Check admin permission first
+        if not is_admin(interaction.user):
+            await interaction.response.defer()
+            await interaction.user.send("You do not have permission to create async races right now")
+            return
+
+        # Extract and parse inputs
+        name = self.name_input.value.strip() if self.name_input.value else None
+        flags = self.flags_input.value.strip() if self.flags_input.value else None
+        race_role = self.race_role_input.value.strip() if self.race_role_input.value else None
+        start_time_iso = self.start_time_input.value.strip() if self.start_time_input.value else None
+        end_time_iso = self.end_time_input.value.strip() if self.end_time_input.value else None
+        coop_str = self.coop_input.value.strip().lower() if self.coop_input.value else None
+
+        # Validate required fields
+        if not name:
+            await interaction.response.defer()
+            await interaction.user.send("You did not submit a name.")
+            return
+
+        if not flags:
+            await interaction.response.defer()
+            await interaction.user.send("You did not submit flags.")
+            return
+
+        # Parse coop boolean
+        coop = False
+        if coop_str:
+            if coop_str.lower() in ("true", "yes", "1"):
+                coop = True
+
+        # Parse timestamps
+        start_timestamp = None
+        end_timestamp = None
+
+        if start_time_iso:
+            start_timestamp = self._iso_to_unix_timestamp(start_time_iso)
+            if start_timestamp is None:
+                await interaction.response.defer()
+                await interaction.user.send("Invalid start time format. Use ISO format: 2026-07-15T10:30:00")
+                return
+
+        if end_time_iso:
+            end_timestamp = self._iso_to_unix_timestamp(end_time_iso)
+            if end_timestamp is None:
+                await interaction.response.defer()
+                await interaction.user.send("Invalid end time format. Use ISO format: 2026-07-15T10:30:00")
+                return
+
+        # Validate role if provided
+        if race_role:
+            role = discord.utils.get(interaction.guild.roles, name=race_role)
+            if role is None:
+                await interaction.response.defer()
+                await interaction.user.send(f"The role '{race_role}' does not exist.")
+                return
+
+        # Create the race
+        try:
+            race = AsyncRace(
+                interaction.channel,
+                name,
+                interaction.user,
+                flags,
+                (
+                    datetime.fromtimestamp(start_timestamp)
+                    if start_timestamp
+                    else None
+                ),
+                (
+                    datetime.fromtimestamp(end_timestamp)
+                    if end_timestamp
+                    else None
+                ),
+                race_role,
+                coop,
+            )
+
+            await race.init_race()
+            self.cog.active_races[race.race_id] = race
+            self.cog._save_one(race)
+
+            await interaction.response.defer()
+            await interaction.user.send(f"✅ Async race '{name}' created successfully!")
+        except Exception as e:
+            await interaction.response.defer()
+            error_msg = f"Error creating race: {str(e)}"
+            logging.error(error_msg)
+            logging.exception(e)
+            await interaction.user.send(error_msg)
+
 
 class AsyncRaces(commands.Cog):
 
@@ -51,54 +206,16 @@ class AsyncRaces(commands.Cog):
         self._delete_one(race.race_id)
 
 
-    @commands.command(aliases=["ca"])
-    async def createasync(self, ctx, *, flags: StartAsyncFlags):
+
+    @app_commands.command(name="createasync", description="Create a new async race using a guided form")
+    async def createasync(self, interaction: discord.Interaction):
         """
-        Creates a new async race
-        Race is created as a thread of the current channel
+        Creates a new async race via a modal form.
+        Shows a modal to guide the user through entering race details.
         """
-        owner = ctx.message.author
-
-        if not is_admin(owner):
-            await owner.send("You do not have permission to create async races right now")
-            await ctx.message.delete()
-            return
-        
-        if flags.name is None:
-            await owner.send("You did not submit a name.")
-            await ctx.message.delete()
-            return
-
-        if flags.race_role is not None:
-            role = get(ctx.channel.guild.roles, name=flags.race_role)
-            if role is None:
-                await owner.send(f"The role '{flags.race_role}' does not exist.")
-                await ctx.message.delete()
-                return
-            
-        race = AsyncRace(
-            ctx.channel,
-            flags.name,
-            owner,
-            flags.flags,
-            (
-                datetime.fromtimestamp(flags.start_timestamp)
-                if flags.start_timestamp
-                else None
-            ),
-            (
-                datetime.fromtimestamp(flags.end_timestamp)
-                if flags.end_timestamp
-                else None
-            ),
-            flags.race_role,
-            False if flags.coop is None else flags.coop,
-        )
-
-        await race.init_race()
-        self.active_races[race.race_id] = race
-        self._save_one(race)
-        await ctx.message.delete()
+        modal = CreateAsyncModal()
+        modal.cog = self
+        await interaction.response.show_modal(modal)
 
 
     @commands.command()

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -111,13 +111,11 @@ class CreateAsyncModal(ui.Modal):
 
         # Validate required fields
         if not name:
-            await interaction.response.defer()
-            await interaction.user.send("You did not submit a name.")
+            await interaction.response.send_message("You did not submit a name.", ephemeral=True)
             return
 
         if not flags:
-            await interaction.response.defer()
-            await interaction.user.send("You did not submit flags.")
+            await interaction.response.send_message("You did not submit flags.", ephemeral=True)
             return
 
         # Parse timestamps
@@ -127,23 +125,20 @@ class CreateAsyncModal(ui.Modal):
         if start_time_iso:
             start_timestamp = self._iso_to_unix_timestamp(start_time_iso)
             if start_timestamp is None:
-                await interaction.response.defer()
-                await interaction.user.send("Invalid start time format. Use ISO format: 2026-07-15T10:30:00")
+                await interaction.response.send_message("Invalid start time format. Use ISO format: 2026-07-15T10:30:00", ephemeral=True)
                 return
 
         if end_time_iso:
             end_timestamp = self._iso_to_unix_timestamp(end_time_iso)
             if end_timestamp is None:
-                await interaction.response.defer()
-                await interaction.user.send("Invalid end time format. Use ISO format: 2026-07-15T10:30:00")
+                await interaction.response.send_message("Invalid end time format. Use ISO format: 2026-07-15T10:30:00", ephemeral=True)
                 return
 
         # Validate role if provided
         if race_role:
             role = discord.utils.get(interaction.guild.roles, name=race_role)
             if role is None:
-                await interaction.response.defer()
-                await interaction.user.send(f"The role '{race_role}' does not exist.")
+                await interaction.response.send_message(f"The role '{race_role}' does not exist.", ephemeral=True)
                 return
 
         # defer now to be able to create in time.
@@ -219,12 +214,10 @@ class AsyncRaces(commands.Cog):
         """
         # Check admin permission first
         if not is_admin(interaction.user):
-            await interaction.response.defer()
-            await interaction.user.send("You do not have permission to create async races right now")
+            await interaction.response.send_message("You do not have permission to create async races right now", ephemeral=True)
             return
         
         if coop.lower() not in ["true", "false"]:
-            await interaction.response.defer()
             await interaction.response.send_message("Invalid value for coop. Use 'true' or 'false'.", ephemeral=True)
             return
         
@@ -369,7 +362,8 @@ class AsyncRaces(commands.Cog):
         user = ctx.message.author
         role = await self.getrole(ctx)
         if (
-            role.name == constants.ducklingrole
+            role is not None 
+            and role.name == constants.ducklingrole
             and constants.rolerequiredduckling not in [role.name for role in user.roles]
         ):
             await user.send("You're not a duckling!")
@@ -609,7 +603,7 @@ class AsyncRaces(commands.Cog):
                 await ctx.message.delete()
             return
 
-        user = ctx.message.author
+        user = ctx.author
         role = await self.getrole(ctx)
 
         if (
@@ -653,7 +647,7 @@ class AsyncRaces(commands.Cog):
                 await ctx.message.delete()
             return 
         
-        user = ctx.message.author
+        user = ctx.interaction.user if ctx.interaction else ctx.message.author
         role = await self.getrole(ctx)
         if role is not None and role.name in constants.nonadminroles:
             await user.add_roles(role)
@@ -672,10 +666,10 @@ class AsyncRaces(commands.Cog):
         :return: Role or None
         """
 
-        user = ctx.message.author
-        roles = ctx.message.guild.roles
-        channel = ctx.message.channel
-        channels = ctx.message.guild.channels
+        user = ctx.author
+        roles = ctx.guild.roles
+        channel = ctx.channel
+        channels = ctx.guild.channels
         challengeseed = get(channels, name=constants.challengeseedchannel)
         asyncseed = get(channels, name=constants.asyncchannel)
         ducklingseed = get(channels, name=constants.ducklingchannel)
@@ -709,9 +703,9 @@ class AsyncRaces(commands.Cog):
         :param ctx: context of the command
         :return: Message or None
         """
-        user = ctx.message.author
-        channel = ctx.message.channel
-        channels = ctx.message.guild.channels
+        user = ctx.author
+        channel = ctx.channel
+        channels = ctx.guild.channels
         challengeseed = get(channels, name=constants.challengeseedchannel)
         asyncseed = get(channels, name=constants.asyncchannel)
         ducklingseed = get(channels, name=constants.ducklingchannel)
@@ -748,9 +742,9 @@ class AsyncRaces(commands.Cog):
         :return: Channel or None
         """
 
-        user = ctx.message.author
-        channel = ctx.message.channel
-        channels = ctx.message.guild.channels
+        user = ctx.author
+        channel = ctx.channel
+        channels = ctx.guild.channels
         challengeseed = get(channels, name=constants.challengeseedchannel)
         asyncseed = get(channels, name=constants.asyncchannel)
         ducklingseed = get(channels, name=constants.ducklingchannel)
@@ -777,7 +771,7 @@ class AsyncRaces(commands.Cog):
         """
 
         participants: List[Message] = (
-            ctx.message.channel if channel is None else channel
+            ctx.channel if channel is None else channel
         ).history(limit=100)
         async for x in participants:
             if x.author == self.bot.user:

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -194,7 +194,7 @@ class AsyncRaces(commands.Cog):
 
         await ctx.message.delete()
 
-    @commands.command()
+    @commands.hybrid_command()
     async def submit(self, ctx, runnertime: str | None = None, vod: str | None = None, teammate: discord.Member = None, teammate_vod: str | None = None):
         """
         Submits a runners time to an async race

--- a/src/cogs/races/async_races.py
+++ b/src/cogs/races/async_races.py
@@ -32,18 +32,11 @@ async def coop_autocomplete(
         for opt in options if current.lower() in opt["name"].lower()
     ]
 
-class StartAsyncFlags(commands.FlagConverter):
-    name: str
-    flags: str
-    race_role: Optional[str]
-    start_timestamp: Optional[int]
-    end_timestamp: Optional[int]
-    coop: Optional[bool] = False
-
 class CreateAsyncModal(ui.Modal):
     """Modal for creating a new async race with guided form inputs."""
     def __init__(self, cog, coop_mode: bool = False):    
         super().__init__(title="Create Async Race")
+        self.cog = cog
         self.coop_mode = coop_mode    
         self.name_input = ui.TextInput(
             label="Race Name",
@@ -208,6 +201,7 @@ class AsyncRaces(commands.Cog):
         return is_admin(user) or any(role.name in constants.adminroles + ["Race Crew Lead"] for role in user.roles)
 
     @app_commands.command(name="createasync", description="Create a new async race using a guided form")
+    @app_commands.guild_only()
     @app_commands.describe(coop="Is this a co-op race? (Default: false)")
     @app_commands.autocomplete(coop=coop_autocomplete) 
     async def createasync(self, interaction: discord.Interaction, coop: str = "false"):
@@ -225,7 +219,6 @@ class AsyncRaces(commands.Cog):
             return
         
         modal = CreateAsyncModal(self, coop_mode=coop.lower() == "true")
-        modal.cog = self
         await interaction.response.send_modal(modal)
 
 
@@ -363,7 +356,7 @@ class AsyncRaces(commands.Cog):
             # submit only on leaderboard
             return
         
-        user = ctx.message.author
+        user = ctx.author
         role = await self.getrole(ctx)
         if (
             role is not None 

--- a/src/cogs/races/races.py
+++ b/src/cogs/races/races.py
@@ -259,6 +259,9 @@ class Races(commands.Cog):
 
     @commands.check(is_call_for_races)
     async def spectate(self, ctx, id):
+        if ctx.interaction:
+            await ctx.interaction.response.defer(thinking=False)
+
         try:
             race = active_races[int(id)]
         except KeyError:
@@ -348,6 +351,9 @@ class Races(commands.Cog):
     @is_runner()
     @commands.check(is_race_room)
     async def forfeit(self, ctx):
+        if ctx.interaction:
+            await ctx.interaction.response.defer(thinking=False)
+
         try:
             race = active_races[ctx.channel.id]
             msg = race.forfeit(aliases[race.id][ctx.author.id])

--- a/src/cogs/races/races.py
+++ b/src/cogs/races/races.py
@@ -258,19 +258,22 @@ class Races(commands.Cog):
         await self.startcountdown(ctx)
 
     @commands.check(is_call_for_races)
-    async def spectate(self, ctx, id):
+    async def spectate(self, ctx):
         if ctx.interaction:
-            await ctx.interaction.response.defer(thinking=False)
+            await ctx.defer(ephemeral=True)
 
         try:
-            race = active_races[int(id)]
-        except KeyError:
-            return
-        await ctx.message.delete()
-        if id:
+            race = active_races[ctx.channel.id]
             await race.channel.send(
                 f"{ctx.author.mention} is now cheering you on from the sidelines"
             )
+        except KeyError:
+            return
+        finally:
+            if ctx.interaction:
+                await ctx.interaction.delete_original_response()
+            else:
+                await ctx.message.delete()
 
     @commands.command(aliases=["r"])
     @is_race_started(toggle=False)
@@ -352,7 +355,7 @@ class Races(commands.Cog):
     @commands.check(is_race_room)
     async def forfeit(self, ctx):
         if ctx.interaction:
-            await ctx.interaction.response.defer(thinking=False)
+            await ctx.defer(ephemeral=True)
 
         try:
             race = active_races[ctx.channel.id]
@@ -364,6 +367,10 @@ class Races(commands.Cog):
         except KeyError:
             await ctx.channel.send("Key Error in the 'forfeit' command")
 
+        if ctx.interaction:
+            await ctx.interaction.delete_original_response()
+
+            
     @commands.command(aliases=["t"])
     @commands.check(is_race_room)
     @is_race_started(toggle=True)

--- a/src/cogs/races/races_common.py
+++ b/src/cogs/races/races_common.py
@@ -29,14 +29,14 @@ class RacesCommon(commands.Cog):
         self.async_races = async_races
 
 
-    @commands.command(aliases=["s", "spec"])
+    @commands.hybrid_command(aliases=["s", "spec"])
     async def spectate(self, ctx):
         if is_race_room(ctx):
             await self.races.spectate(ctx, -1)
             return
         await self.async_races.spectate(ctx)
 
-    @commands.command(aliases=["ff", "dnf"])
+    @commands.hybrid_command(aliases=["ff", "dnf"])
     async def forfeit(self, ctx, teammate: Optional[discord.Member] = None):
         if is_race_room(ctx):
             await self.races.forfeit(ctx)

--- a/src/cogs/races/races_common.py
+++ b/src/cogs/races/races_common.py
@@ -29,14 +29,14 @@ class RacesCommon(commands.Cog):
         self.async_races = async_races
 
 
-    @commands.hybrid_command(aliases=["s", "spec"])
+    @commands.hybrid_command(aliases=["s", "spec"], description="Spectate the current race and get added to the race / spoiler channels")
     async def spectate(self, ctx):
         if is_race_room(ctx):
             await self.races.spectate(ctx, -1)
             return
         await self.async_races.spectate(ctx)
 
-    @commands.hybrid_command(aliases=["ff", "dnf"])
+    @commands.hybrid_command(aliases=["ff", "dnf"], description="Forfeit the race. For asyncs no VOD is required")
     async def forfeit(self, ctx, teammate: Optional[discord.Member] = None):
         if is_race_room(ctx):
             await self.races.forfeit(ctx)

--- a/src/cogs/races/races_common.py
+++ b/src/cogs/races/races_common.py
@@ -32,12 +32,15 @@ class RacesCommon(commands.Cog):
     @commands.hybrid_command(aliases=["s", "spec"], description="Spectate the current race and get added to the race / spoiler channels")
     async def spectate(self, ctx):
         if is_race_room(ctx):
-            await self.races.spectate(ctx, -1)
+            await self.races.spectate(ctx)
             return
         await self.async_races.spectate(ctx)
 
     @commands.hybrid_command(aliases=["ff", "dnf"], description="Forfeit the race. For asyncs no VOD is required")
     async def forfeit(self, ctx, teammate: Optional[discord.Member] = None):
+        """
+        :param teammate: optional (async only) teammate to forfeit for, if any
+        """
         if is_race_room(ctx):
             await self.races.forfeit(ctx)
             return

--- a/src/main.py
+++ b/src/main.py
@@ -65,17 +65,6 @@ async def on_ready():
     logging.info(bot.user.id)
     logging.info("------")
 
-@bot.command
-async def sync(ctx):
-    if (ctx.author.id != constants.poor_soul_id):
-        await ctx.author.send("You don't have permission to use this command.")
-        return
-    
-    await bot.tree.sync(ctx.guild)    
-    await ctx.author.send("Synced commands for this guild")
-    await bot.tree.sync()
-    await ctx.author.send("Synced commands globally")
-
 @bot.event
 async def on_command_error(ctx, error):
     poor_soul = bot.get_user(constants.poor_soul_id)

--- a/src/main.py
+++ b/src/main.py
@@ -52,9 +52,9 @@ redis_polls = redis.StrictRedis(connection_pool=redis_pool)
 async def on_ready():
     await bot.tree.sync()
     for guild in bot.guilds:
-        cmds = bot.tree.get_commands(guild=guild)
-        if cmds:
-            await bot.tree.sync(guild=guild)
+        logging.info(f"Syncing commands for guild {guild.name} ({guild.id})")
+        await bot.tree.sync(guild=guild)
+
     async_races = bot.get_cog("AsyncRaces")
     if (async_races is not None):
         await async_races.load_data(bot)

--- a/src/main.py
+++ b/src/main.py
@@ -50,11 +50,6 @@ redis_polls = redis.StrictRedis(connection_pool=redis_pool)
 
 @bot.event
 async def on_ready():
-    await bot.tree.sync()
-    for guild in bot.guilds:
-        logging.info(f"Syncing commands for guild {guild.name} ({guild.id})")
-        await bot.tree.sync(guild=guild)
-
     async_races = bot.get_cog("AsyncRaces")
     if (async_races is not None):
         await async_races.load_data(bot)
@@ -70,6 +65,16 @@ async def on_ready():
     logging.info(bot.user.id)
     logging.info("------")
 
+@bot.command
+async def sync(ctx):
+    if (ctx.author.id != constants.poor_soul_id):
+        await ctx.author.send("You don't have permission to use this command.")
+        return
+    
+    await bot.tree.sync(ctx.guild)    
+    await ctx.author.send("Synced commands for this guild")
+    await bot.tree.sync()
+    await ctx.author.send("Synced commands globally")
 
 @bot.event
 async def on_command_error(ctx, error):


### PR DESCRIPTION
Making `createAsync` an app_command rather than a standard command so that we can use a modal for it and give inputs.

Converting `?spec`, `?ff` and `?submit` to be "hybrid" commands, where we can use them as either `?` commands or slash / app commands. This prevents notifications from accidentally spoiling times.